### PR TITLE
Makes the properties_dark property optional

### DIFF
--- a/packages/plugin/src/tailwind/themes/index.ts
+++ b/packages/plugin/src/tailwind/themes/index.ts
@@ -24,7 +24,7 @@ export type ObjectKeys<T> = keyof T;
 export type BaseTheme = {
 	name: string;
 	properties: ThemeProperties;
-	properties_dark: Partial<ThemeProperties>;
+	properties_dark?: Partial<ThemeProperties>;
 };
 
 export type PresetTheme = BaseTheme & {


### PR DESCRIPTION
The official theme generator tool already gives us the dark theme data, no need for this property to be mandatory

## Linked Issue

Closes #{issueNumber}

## Description

When you copy/paste the generated theme from the official tool, it complains that we are missing a property from the BaseTheme

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
